### PR TITLE
Named Methods

### DIFF
--- a/commonjs_wrapper.js.erb
+++ b/commonjs_wrapper.js.erb
@@ -44,7 +44,8 @@ function fix_and_export(class_name) {
           var pub_name = a.replace(/_va$/, '');
           Fixed[pub_name] = function wrap_classmeth () {
             var args = Array.prototype.slice.call(arguments);
-            return wrap_classmeth.inner_method(args);
+            var m = wrap_classmeth.inner_method ? wrap_classmeth.inner_method : arguments.callee.inner_method;
+            return m.apply(this, [args]);
           };
           Fixed[pub_name].inner_method = Src[a];
         }
@@ -58,7 +59,8 @@ function fix_and_export(class_name) {
       var pub_name = a.replace(/_va$/, '');
       proto[pub_name] = function wrap_meth() {
         var args = Array.prototype.slice.call(arguments);
-        return wrap_meth.inner_method.apply(this, [args]);
+        var m = wrap_meth.inner_method ? wrap_meth.inner_method : arguments.callee.inner_method;
+        return m.apply(this, [args]);
       };
       proto[pub_name].inner_method = proto[a];
       delete proto[a];


### PR DESCRIPTION
I think that the changes I made here will resolve the IE8 issues.  Essentially, if the named method is undefined we look at the deprecated arguments.callee.  This is in response to:

https://github.com/iriscouch/bigdecimal.js/issues/2

I'm sorry didn't take the time to run it through a build.  But, thought it might be helpful to pass this change along.
