### PR TITLE
Fixing issue #9 - "Issues when adding custom methods to Array.prototype with bigdecimal.js'"

### DIFF
--- a/BigDecimalApp/src/com/iriscouch/gwtapp/client/JsArgs.java
+++ b/BigDecimalApp/src/com/iriscouch/gwtapp/client/JsArgs.java
@@ -43,21 +43,21 @@ class JsArgs extends JavaScriptObject {
 
   public static final native String signature(JsArgs self) /*-{
     var result = [];
-    for (var a in self) {
-      var type = typeof(self[a]);
+    for (var i=0; i<self.length; i++) {
+      var type = typeof(self[i]);
       if(type != 'object')
         result[result.length] = type;
-      else if(self[a] instanceof Array)
+      else if(self[i] instanceof Array)
         result[result.length] = 'array';
       else {
         // An object, but possibly an instance of a known type.
-        if($wnd && $wnd.bigdecimal && $wnd.bigdecimal.BigInteger && (self[a] instanceof $wnd.bigdecimal.BigInteger))
+        if($wnd && $wnd.bigdecimal && $wnd.bigdecimal.BigInteger && (self[i] instanceof $wnd.bigdecimal.BigInteger))
           result[result.length] = 'BigInteger';
-        else if($wnd && $wnd.bigdecimal && $wnd.bigdecimal.BigDecimal && (self[a] instanceof $wnd.bigdecimal.BigDecimal))
+        else if($wnd && $wnd.bigdecimal && $wnd.bigdecimal.BigDecimal && (self[i] instanceof $wnd.bigdecimal.BigDecimal))
           result[result.length] = 'BigDecimal';
-        else if($wnd && $wnd.bigdecimal && $wnd.bigdecimal.RoundingMode && (self[a] instanceof $wnd.bigdecimal.RoundingMode))
+        else if($wnd && $wnd.bigdecimal && $wnd.bigdecimal.RoundingMode && (self[i] instanceof $wnd.bigdecimal.RoundingMode))
           result[result.length] = 'RoundingMode';
-        else if($wnd && $wnd.bigdecimal && $wnd.bigdecimal.MathContext && (self[a] instanceof $wnd.bigdecimal.MathContext))
+        else if($wnd && $wnd.bigdecimal && $wnd.bigdecimal.MathContext && (self[i] instanceof $wnd.bigdecimal.MathContext))
           result[result.length] = 'MathContext';
         else
           result[result.length] = 'object';
@@ -65,7 +65,7 @@ class JsArgs extends JavaScriptObject {
     }
     return result.join(' ');
   }-*/;
-
+  
   public final native void push(JavaScriptObject obj) /*-{
     this[this.length] = obj;
   }-*/;

--- a/commonjs_wrapper.js.erb
+++ b/commonjs_wrapper.js.erb
@@ -44,7 +44,8 @@ function fix_and_export(class_name) {
           var pub_name = a.replace(/_va$/, '');
           Fixed[pub_name] = function wrap_classmeth () {
             var args = Array.prototype.slice.call(arguments);
-            return wrap_classmeth.inner_method(args);
+            var m = wrap_classmeth.inner_method ? wrap_classmeth.inner_method : arguments.callee.inner_method;
+            return m.apply(this, [args]);
           };
           Fixed[pub_name].inner_method = Src[a];
         }
@@ -58,7 +59,8 @@ function fix_and_export(class_name) {
       var pub_name = a.replace(/_va$/, '');
       proto[pub_name] = function wrap_meth() {
         var args = Array.prototype.slice.call(arguments);
-        return wrap_meth.inner_method.apply(this, [args]);
+        var m = wrap_meth.inner_method ? wrap_meth.inner_method : arguments.callee.inner_method;
+        return m.apply(this, [args]);
       };
       proto[pub_name].inner_method = proto[a];
       delete proto[a];


### PR DESCRIPTION
Improving the way JsArgs performs signature checking by using a better method of array iteration. This will avoid errors if anyone has code that adds methods to Array.prototype.

See issue #9 on the github page: 'Issues when adding custom methods to Array.Prototype with bigdecimal.js'.
